### PR TITLE
Update google-api-client to v0.52 support Ruby 3. See SDK-7233.

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |spec|
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.
-  spec.add_dependency('google-api-client', '>= 0.37.0', '< 0.39.0') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-api-client', '>= 0.52.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog


### PR DESCRIPTION
See SDK-7233. Keep this pull request open for reference purposes.